### PR TITLE
Add react@18 to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "react": "^17.0.2"
+    "react": "^17.0.2 || ^18.0.0"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
This PR adds react 18 to the peer dependencies.

When trying to install this library you currently get this error if you are using react 18:

```
While resolving: web@0.1.0
Found: react@18.2.0
node_modules/react
  react@"18.2.0" from the root project

Could not resolve dependency:
peer react@"^17.0.2" from react-jsbarcode@0.2.4
node_modules/react-jsbarcode
  react-jsbarcode@"*" from the root project

Fix the upstream dependency conflict, or retry
this command with --force, or --legacy-peer-deps
to accept an incorrect (and potentially broken) dependency resolution.
```